### PR TITLE
Storyboard compatibility

### DIFF
--- a/clock/Classes/ClockView.m
+++ b/clock/Classes/ClockView.m
@@ -112,6 +112,26 @@ float Degrees2Radians(float degrees) { return degrees * M_PI / 180; }
 	hourHand.transform = CATransform3DMakeRotation (hourAngle+M_PI, 0, 0, 1);
 }
 
+-(void)defaultSetup
+{
+    containerLayer = [CALayer layer];
+    hourHand = [CALayer layer];
+    minHand = [CALayer layer];
+    secHand = [CALayer layer];
+    
+    //default appearance
+    [self setClockBackgroundImage:NULL];
+    [self setHourHandImage:NULL];
+    [self setMinHandImage:NULL];
+    [self setSecHandImage:NULL];
+    
+    //add all created sublayers
+    [containerLayer addSublayer:hourHand];
+    [containerLayer addSublayer:minHand];
+    [containerLayer addSublayer:secHand];
+    [self.layer addSublayer:containerLayer];
+}
+
 #pragma mark - Overrides
 
 - (void) layoutSubviews
@@ -167,25 +187,17 @@ float Degrees2Radians(float degrees) { return degrees * M_PI / 180; }
 {
 	self = [super initWithFrame:frame];
 	if (self) {
-		
-		containerLayer = [CALayer layer];
-		hourHand = [CALayer layer];
-		minHand = [CALayer layer];
-		secHand = [CALayer layer];
-
-		//default appearance
-		[self setClockBackgroundImage:NULL];
-		[self setHourHandImage:NULL];
-		[self setMinHandImage:NULL];
-		[self setSecHandImage:NULL];
-		
-		//add all created sublayers
-		[containerLayer addSublayer:hourHand];
-		[containerLayer addSublayer:minHand];
-		[containerLayer addSublayer:secHand];
-		[self.layer addSublayer:containerLayer];
+        
+		[self defaultSetup];
+        
 	}
 	return self;
+}
+
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    [self defaultSetup];
 }
 
 - (void)removeFromSuperview

--- a/clock/Classes/ClockViewController.h
+++ b/clock/Classes/ClockViewController.h
@@ -14,7 +14,7 @@
 {
 }
 
-@property (nonatomic, strong) ClockView *clockView1;
-@property (nonatomic, strong) ClockView *clockView2;
+@property (nonatomic, strong) IBOutlet ClockView *clockView1;
+@property (nonatomic, strong) IBOutlet ClockView *clockView2;
 
 @end

--- a/clock/Classes/ClockViewController.m
+++ b/clock/Classes/ClockViewController.m
@@ -37,19 +37,11 @@
 	// http://www.comparestoreprices.co.uk/wall-clocks/bliss-roman-aluminium-clock.asp
 	// It can be found in Images folder: bliss-roman-aluminium-clock.jpg
 		
-	//ClockView with some images
-	clockView1 = [[ClockView alloc] initWithFrame:CGRectMake(-15, 0, 350, 350)];
-	[clockView1 setClockBackgroundImage:[UIImage imageNamed:@"clock-background.png"].CGImage];
+	// We customize the background images of clockView1, while clockView2 has default background.
+    [clockView1 setClockBackgroundImage:[UIImage imageNamed:@"clock-background.png"].CGImage];
 	[clockView1 setHourHandImage:[UIImage imageNamed:@"clock-hour-background.png"].CGImage];
 	[clockView1 setMinHandImage:[UIImage imageNamed:@"clock-min-background.png"].CGImage];
 	[clockView1 setSecHandImage:[UIImage imageNamed:@"clock-sec-background.png"].CGImage];
-	clockView1.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-	[self.view addSubview:clockView1];
-	
-	//ClockView with default style
-	clockView2 = [[ClockView alloc] initWithFrame:CGRectMake(0, 320, 100, 100)];
-	clockView2.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-	[self.view addSubview:clockView2];
 
 }
 

--- a/clock/Classes/ClockViewController.xib
+++ b/clock/Classes/ClockViewController.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1056</int>
-		<string key="IBDocument.SystemVersion">10K540</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1306</string>
-		<string key="IBDocument.AppKitVersion">1038.36</string>
-		<string key="IBDocument.HIToolboxVersion">461.00</string>
+		<int key="IBDocument.SystemTarget">1552</int>
+		<string key="IBDocument.SystemVersion">11G63</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1138.51</string>
+		<string key="IBDocument.HIToolboxVersion">569.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">301</string>
+			<string key="NS.object.0">2083</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -20,11 +20,8 @@
 			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<object class="NSArray" key="dict.sortedKeys" id="0">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-			</object>
-			<reference key="dict.values" ref="0"/>
+			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
+			<integer value="1" key="NS.object.0"/>
 		</object>
 		<object class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -39,15 +36,46 @@
 			<object class="IBUIView" id="191373211">
 				<reference key="NSNextResponder"/>
 				<int key="NSvFlags">274</int>
+				<object class="NSMutableArray" key="NSSubviews">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+					<object class="IBUIView" id="967473927">
+						<reference key="NSNextResponder" ref="191373211"/>
+						<int key="NSvFlags">314</int>
+						<string key="NSFrame">{{22, 12}, {276, 257}}</string>
+						<reference key="NSSuperview" ref="191373211"/>
+						<reference key="NSWindow"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<object class="NSColor" key="IBUIBackgroundColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MQA</bytes>
+							<object class="NSColorSpace" key="NSCustomColorSpace" id="360795664">
+								<int key="NSID">2</int>
+							</object>
+						</object>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+					</object>
+					<object class="IBUIView" id="174240954">
+						<reference key="NSNextResponder" ref="191373211"/>
+						<int key="NSvFlags">314</int>
+						<string key="NSFrame">{{80, 299}, {160, 131}}</string>
+						<reference key="NSSuperview" ref="191373211"/>
+						<reference key="NSWindow"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<object class="NSColor" key="IBUIBackgroundColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MQA</bytes>
+							<reference key="NSCustomColorSpace" ref="360795664"/>
+						</object>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+					</object>
+				</object>
 				<string key="NSFrame">{{0, 20}, {320, 460}}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">3</int>
 					<bytes key="NSWhite">MQA</bytes>
-					<object class="NSColorSpace" key="NSCustomColorSpace">
-						<int key="NSID">2</int>
-					</object>
+					<reference key="NSCustomColorSpace" ref="360795664"/>
 				</object>
 				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
 				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -64,19 +92,42 @@
 					</object>
 					<int key="connectionID">3</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">clockView1</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="967473927"/>
+					</object>
+					<int key="connectionID">6</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">clockView2</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="174240954"/>
+					</object>
+					<int key="connectionID">7</int>
+				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<object class="NSArray" key="orderedObjects">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<object class="IBObjectRecord">
 						<int key="objectID">0</int>
-						<reference key="object" ref="0"/>
+						<object class="NSArray" key="object" id="0">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+						</object>
 						<reference key="children" ref="1000"/>
 						<nil key="parent"/>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">1</int>
 						<reference key="object" ref="191373211"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="174240954"/>
+							<reference ref="967473927"/>
+						</object>
 						<reference key="parent" ref="0"/>
 					</object>
 					<object class="IBObjectRecord">
@@ -90,6 +141,16 @@
 						<reference key="object" ref="975951072"/>
 						<reference key="parent" ref="0"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">4</int>
+						<reference key="object" ref="967473927"/>
+						<reference key="parent" ref="191373211"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">5</int>
+						<reference key="object" ref="174240954"/>
+						<reference key="parent" ref="191373211"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -97,15 +158,25 @@
 				<object class="NSArray" key="dict.sortedKeys">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>-1.CustomClassName</string>
+					<string>-1.IBPluginDependency</string>
 					<string>-2.CustomClassName</string>
-					<string>1.IBEditorWindowLastContentRect</string>
+					<string>-2.IBPluginDependency</string>
 					<string>1.IBPluginDependency</string>
+					<string>4.CustomClassName</string>
+					<string>4.IBPluginDependency</string>
+					<string>5.CustomClassName</string>
+					<string>5.IBPluginDependency</string>
 				</object>
-				<object class="NSMutableArray" key="dict.values">
+				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>ClockViewController</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>UIResponder</string>
-					<string>{{556, 412}, {320, 480}}</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>ClockView</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>ClockView</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				</object>
 			</object>
@@ -121,7 +192,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">3</int>
+			<int key="maxID">7</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -138,14 +209,35 @@
 					<string key="className">ClockViewController</string>
 					<string key="superclassName">UIViewController</string>
 					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">clockView</string>
-						<string key="NS.object.0">ClockView</string>
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>clockView1</string>
+							<string>clockView2</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>ClockView</string>
+							<string>ClockView</string>
+						</object>
 					</object>
 					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">clockView</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">clockView</string>
-							<string key="candidateClassName">ClockView</string>
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>clockView1</string>
+							<string>clockView2</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBToOneOutletInfo">
+								<string key="name">clockView1</string>
+								<string key="candidateClassName">ClockView</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">clockView2</string>
+								<string key="candidateClassName">ClockView</string>
+							</object>
 						</object>
 					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
@@ -163,6 +255,6 @@
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">301</string>
+		<string key="IBCocoaTouchPluginVersion">2083</string>
 	</data>
 </archive>


### PR DESCRIPTION
Dear nacho4d,
I bet you speak Spanish, así que voy a seguir en Castellano en este mensaje. Eso sí, dejo claro que mis mensajes de commit están siempre en inglés.

Mis modificaciones permiten usar `ClockView` de manera más amigable a través de Interface Builder. Ahora puedes agregar una vista usando el mouse, declarar que es de clase `ClockView`, y con eso ya funciona el reloj por defecto. Si quieres un reloj personalizado, puedes cambiar las imágenes de fondo en el `viewDidLoad`, como siempre. Todo esto lo puedes ver en acción en el controlador de ejemplo `ClockViewController`, que he actualizado.

Todo esto fue posible gracias a que implementé `awakeFromNib` en `ClockView.m`, que se ejecuta después de desarchivar un objeto desde un archivo `.xib` o `.nib`.

Tus comentarios son bienvenidos, y gracias por tu código.

Atentamente,
Antonio
